### PR TITLE
Adding http->https redirection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,18 +1,21 @@
 import os
-
+from werkzeug.contrib.fixers import ProxyFix
 from flask import Flask
 
 from config import configs
 from flask._compat import string_types
+from .proxy_fix import init_app
 
 
 def create_app(config_name):
     application = Flask(__name__)
+
     application.config['NOTIFY_API_ENVIRONMENT'] = config_name
 
     application.config.from_object(configs[config_name])
-
     init_app(application)
+
+    proxy_fix.init_app(application)
 
     from .main import main as main_blueprint
     application.register_blueprint(main_blueprint)
@@ -24,7 +27,6 @@ def init_app(app):
     for key, value in app.config.items():
         if key in os.environ:
             app.config[key] = convert_to_boolean(os.environ[key])
-    app.config['NOTIFY_API_ENVIRONMENT'] = os.environ.get('NOTIFY_API_ENVIRONMENT', 'development')
 
 
 def convert_to_boolean(value):

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,5 +1,19 @@
-from flask import Blueprint
+from flask import Blueprint, current_app, request, redirect
 
 main = Blueprint('main', __name__)
 
 from .views import notify
+
+
+def check_url_scheme():
+    """
+    On heroku builds need to ensure that http calls are redirected to https
+    """
+    if current_app.config.get('NOTIFY_API_ENVIRONMENT', 'development') == 'live':
+        scheme = request.headers.get('HTTP_X_FORWARDED_PROTO', 'http')
+        preferred_scheme = current_app.config.get('NOTIFY_HTTP_PROTO', 'http')
+        if scheme != preferred_scheme:
+            return redirect(request.url.replace('http://', 'https://', 1), code=301)
+
+
+main.before_request(check_url_scheme)

--- a/app/main/views/notify.py
+++ b/app/main/views/notify.py
@@ -1,4 +1,4 @@
-from flask import jsonify, url_for
+from flask import jsonify, url_for, current_app
 
 from .. import main
 
@@ -8,7 +8,10 @@ def index():
     """Entry point for the API, show the resources that are available."""
     return jsonify(links={
         "notification.create": {
-            "url": url_for('.create_notification', _external=True),
+            "url": url_for(
+                '.create_notification',
+                _external=True,
+            ),
             "method": "POST"
         }
     }

--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -1,0 +1,18 @@
+from werkzeug.contrib.fixers import ProxyFix
+
+
+class CustomProxyFix(object):
+    def __init__(self, app, forwarded_proto):
+        self.app = ProxyFix(app)
+        self.forwarded_proto = forwarded_proto
+
+    def __call__(self, environ, start_response):
+        environ.update({
+            "HTTP_X_FORWARDED_PROTO": self.forwarded_proto
+        })
+        return self.app(environ, start_response)
+
+
+def init_app(app):
+    app.wsgi_app = CustomProxyFix(app.wsgi_app,
+                                  app.config.get('NOTIFY_HTTP_PROTO', 'http'))

--- a/application.py
+++ b/application.py
@@ -9,7 +9,7 @@ from flask.ext.script import Manager, Server
 from app import create_app
 
 
-application = create_app(os.getenv('ENVIRONMENT') or 'development')
+application = create_app(os.getenv('NOTIFY_API_ENVIRONMENT') or 'development')
 manager = Manager(application)
 port = int(os.environ.get('PORT', 6001))
 manager.add_command("runserver", Server(host='0.0.0.0', port=port))

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 
-class Config:
+class Config(object):
     DEBUG = False
+    NOTIFY_HTTP_PROTO = 'http'
 
 
 class Development(Config):
@@ -12,8 +13,8 @@ class Test(Config):
 
 
 class Live(Config):
-    """Base config for deployed environments"""
-    pass
+    NOTIFY_HTTP_PROTO = "https"
+
 
 configs = {
     'development': Development,

--- a/tests/test_api_authentication.py
+++ b/tests/test_api_authentication.py
@@ -1,3 +1,0 @@
-
-def test():
-    assert 1 == 1

--- a/tests/test_api_setup.py
+++ b/tests/test_api_setup.py
@@ -1,0 +1,23 @@
+import os
+from app import create_app
+from flask import json
+
+
+def test_should_reject_http_traffic_on_production_configuration():
+    app = create_app('live')
+    with app.app_context():
+        client = app.test_client()
+        response = client.get('/')
+        assert response.status_code == 301
+        assert response.location == 'https://localhost/'
+
+
+def test_should_render_production_links_with_https():
+    os.environ['NOTIFY_HTTP_PROTO'] = 'https'
+    app = create_app('development')
+    with app.app_context():
+        client = app.test_client()
+        response = client.get('/')
+        data = json.loads(response.get_data())
+        assert 200 == response.status_code
+        assert data['links']['notification.create']['url'] == "https://localhost/notification"


### PR DESCRIPTION
- If the config requests https and the HTTP_X_FORWARDED_PROTO is missing or http then perform a 301 redirect to https
- use proxy fix module to patch the _wsgi_app_ so that _url_for_ methods behave correctly
