### PR TITLE
Using cached forwarded headers as original is over written by proxy fix.

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -10,7 +10,7 @@ def check_url_scheme():
     On heroku builds need to ensure that http calls are redirected to https
     """
     if current_app.config.get('NOTIFY_API_ENVIRONMENT', 'development') == 'live':
-        scheme = request.headers.get('HTTP_X_FORWARDED_PROTO', 'http')
+        scheme = request.headers.get('werkzeug.proxy_fix.orig_wsgi_url_scheme', 'http')
         preferred_scheme = current_app.config.get('NOTIFY_HTTP_PROTO', 'http')
         if scheme != preferred_scheme:
             return redirect(request.url.replace('http://', 'https://', 1), code=301)

--- a/app/main/views/notify.py
+++ b/app/main/views/notify.py
@@ -1,4 +1,4 @@
-from flask import jsonify, url_for, current_app
+from flask import jsonify, url_for
 
 from .. import main
 

--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -14,5 +14,4 @@ class CustomProxyFix(object):
 
 
 def init_app(app):
-    app.wsgi_app = CustomProxyFix(app.wsgi_app,
-                                  app.config.get('NOTIFY_HTTP_PROTO', 'http'))
+    app.wsgi_app = CustomProxyFix(app.wsgi_app, app.config.get('NOTIFY_HTTP_PROTO', 'http'))


### PR DESCRIPTION
Fix redirect bug on heroku
