### PR TITLE
Adding authentication tokens

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,8 +1,9 @@
-from flask import Blueprint, current_app, request, redirect
+from flask import Blueprint, current_app, request, redirect, abort
 
 main = Blueprint('main', __name__)
 
 from .views import notify
+from . import errors
 
 
 def check_url_scheme():
@@ -16,4 +17,33 @@ def check_url_scheme():
             return redirect(request.url.replace('http://', 'https://', 1), code=301)
 
 
+def requires_authentication():
+    if current_app.config['AUTH_REQUIRED']:
+        incoming_token = get_token_from_headers(request.headers)
+
+        if not incoming_token:
+            abort(401)
+        if not token_is_valid(incoming_token):
+            abort(403, incoming_token)
+
+
+def token_is_valid(incoming_token):
+    return incoming_token == current_app.config.get("API_TOKEN")
+
+
+def get_token_from_headers(headers):
+    auth_header = headers.get('Authorization', '')
+    if auth_header[:7] != 'Bearer ':
+        return None
+    return auth_header[7:]
+
+
 main.before_request(check_url_scheme)
+
+main.before_request(requires_authentication)
+
+
+@main.after_request
+def add_cache_control(response):
+    response.cache_control.max_age = 24 * 60 * 60
+    return response

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,0 +1,33 @@
+from flask import jsonify
+
+from . import main
+
+
+@main.app_errorhandler(400)
+def bad_request(e):
+    # TODO: log the error
+    return jsonify(error=e.description), 400
+
+
+@main.app_errorhandler(401)
+def unauthorized(e):
+    error_message = "Unauthorized, bearer token must be provided"
+    return jsonify(error=error_message), 401, [('WWW-Authenticate', 'Bearer')]
+
+
+@main.app_errorhandler(403)
+def forbidden(e):
+    error_message = "Forbidden, invalid bearer token provided '{}'".format(
+        e.description)
+    return jsonify(error=error_message), 403
+
+
+@main.app_errorhandler(404)
+def page_not_found(e):
+    return jsonify(error=e.description or "Not found"), 404
+
+
+@main.app_errorhandler(500)
+def internal_server_error(e):
+    # TODO: log the error
+    return jsonify(error="Internal error"), 500

--- a/config.py
+++ b/config.py
@@ -2,6 +2,8 @@
 class Config(object):
     DEBUG = False
     NOTIFY_HTTP_PROTO = 'http'
+    AUTH_REQUIRED = True
+    API_TOKEN = 'valid-token'
 
 
 class Development(Config):

--- a/tests/test_api_setup.py
+++ b/tests/test_api_setup.py
@@ -1,23 +1,44 @@
 import os
 from app import create_app
 from flask import json
+from tests.test_helpers import BaseApiTest
 
 
-def test_should_reject_http_traffic_on_production_configuration():
-    app = create_app('live')
-    with app.app_context():
-        client = app.test_client()
-        response = client.get('/')
-        assert response.status_code == 301
-        assert response.location == 'https://localhost/'
+class TestApiSetUp(BaseApiTest):
 
+    @staticmethod
+    def test_should_reject_non_https_traffic_on_production_configuration(self):
+        app = create_app('live')
+        with app.app_context():
+            client = app.test_client()
+            response = client.get('/')
+            assert response.status_code == 301
+            assert response.location == 'https://localhost/'
 
-def test_should_render_production_links_with_https():
-    os.environ['NOTIFY_HTTP_PROTO'] = 'https'
-    app = create_app('development')
-    with app.app_context():
-        client = app.test_client()
-        response = client.get('/')
+    def test_should_render_production_links_with_https(self):
+        self.app.config['NOTIFY_HTTP_PROTO'] = 'https'
+        response = self.client.get('/')
         data = json.loads(response.get_data())
         assert 200 == response.status_code
         assert data['links']['notification.create']['url'] == "https://localhost/notification"
+
+    def test_returns_404(self):
+        response = self.client.get('/not-found')
+        assert 404 == response.status_code
+
+    def test_bearer_token_is_required(self):
+        self.do_not_provide_access_token()
+        response = self.client.get('/')
+        assert 401 == response.status_code
+        assert 'WWW-Authenticate' in response.headers
+
+    def test_valid_bearer_token_is_required(self):
+        self.do_not_provide_access_token()
+        response = self.client.get(
+            '/',
+            headers={'Authorization': 'Bearer invalid-token'})
+        assert 403 == response.status_code
+
+    def test_max_age_is_one_day(self):
+        response = self.client.get("/")
+        assert 86400 == response.cache_control.max_age

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,32 @@
+from app import create_app
+import os
+
+
+class WSGIApplicationWithEnvironment(object):
+    def __init__(self, app, **kwargs):
+        self.app = app
+        self.kwargs = kwargs
+
+    def __call__(self, environ, start_response):
+        for key, value in self.kwargs.items():
+            environ[key] = value
+        return self.app(environ, start_response)
+
+
+class BaseApiTest(object):
+
+    def setup(self):
+        self.app = create_app('test')
+        self.client = self.app.test_client()
+        self.setup_authorization()
+
+    def setup_authorization(self):
+        """Set up bearer token and pass on all requests"""
+        valid_token = 'valid-token'
+        self.app.wsgi_app = WSGIApplicationWithEnvironment(
+            self.app.wsgi_app,
+            HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
+        self._auth_tokens = os.environ.get('DM_API_AUTH_TOKENS')
+
+    def do_not_provide_access_token(self):
+        self.app.wsgi_app = self.app.wsgi_app.app


### PR DESCRIPTION
- configured in the config file
- local build has one valid token - used in tests and for development
- overridden with a private one in live

Responses:
- 401 for no token
- 403 for invalid token

Also adds caching headers - all responses with a cache header of 24 hours.
